### PR TITLE
Add support for sharing themes

### DIFF
--- a/components/Settings.jsx
+++ b/components/Settings.jsx
@@ -7,6 +7,6 @@ module.exports = ({ getSetting, toggleSetting }) => <>
         onChange={() => {
             toggleSetting('linkEmbed', false)
         }}
-        note="When enabled, plugin links sent will not show an embed."
+        note="When enabled, plugin and theme links sent will not show an embed."
     >Hide Link Embed</SwitchItem>
 </>

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Share",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "author": "12944qwerty",
     "license": "MIT",
     "description": "A command to share a plugin or theme that you have installed."

--- a/manifest.json
+++ b/manifest.json
@@ -3,5 +3,5 @@
     "version": "1.0.0",
     "author": "12944qwerty",
     "license": "MIT",
-    "description": "A command to share a plugin that you have installed."
+    "description": "A command to share a plugin or theme that you have installed."
 }


### PR DESCRIPTION
wanted a way to share themes with my friends quickly, so i decided to contribute

this PR adds a command (.share_theme) which copies all the internal logic of the share_plugin command and changes it to work for themes

lmk if you want any changes